### PR TITLE
Add a call_ext function to allow config overrides

### DIFF
--- a/raven/init.lua
+++ b/raven/init.lua
@@ -11,8 +11,16 @@ local util = require 'raven.util'
 local cjson = require 'cjson'
 
 local _M = {}
+
 _M._VERSION = util._VERSION
 
+local unpack = unpack
+local xpcall = xpcall
+local assert = assert
+local pcall = pcall
+local pairs = pairs
+local tostring = tostring
+local setmetatable = setmetatable
 local debug_getinfo = debug.getinfo
 local table_insert = table.insert
 local unpack = unpack or table.unpack -- luacheck: ignore
@@ -21,6 +29,8 @@ local iso8601 = util.iso8601
 local json_encode = cjson.encode
 
 local catcher_trace_level = 4
+
+setfenv(1, {})
 
 --- Table describing main Sentry client settings.
 -- @field sender Object used to send message, see `rave.senders.*` modules to
@@ -31,7 +41,6 @@ local catcher_trace_level = 4
 --  `{ "foo"="bar", ... }`
 -- @field extra  Default extra data sent with messages, defaults to `{}`
 -- @table sentry_conf
-
 local raven_mt = { }
 raven_mt.__index = raven_mt
 

--- a/raven/init.lua
+++ b/raven/init.lua
@@ -377,12 +377,27 @@ end
 -- end
 -- return rvn:call(func, 1, 'foo', true)
 function raven_mt:call(f, ...)
+    return self:call_ext(nil, f, ...)
+end
+
+--- Call given function and report any errors to Sentry with conf overrides.
+-- @function Raven:call_ext
+-- @param conf   Conf overrides
+-- @param f     function to be called
+-- @param ...   function's arguments
+-- @return      the same as @{xpcall}
+-- @usage
+-- function func(a, b, c)
+--     return a * b + c
+-- end
+-- return rvn:call_ext({}, func, 1, 'foo', true)
+function raven_mt:call_ext(conf, f, ...)
     -- When used with ngx_lua, connecting a tcp socket in xpcall error handler
     -- will cause a "yield across C-call boundary" error. To avoid this, we
     -- move all the network operations outside of the xpcall error handler.
     local res = { xpcall(f, capture_error_handler, ...) }
     if not res[1] then
-        self:send_report(res[2])
+        self:send_report(res[2], conf)
         res[2] = res[2].message -- turn the error object back to its initial form
     end
 

--- a/raven/senders/luasocket.lua
+++ b/raven/senders/luasocket.lua
@@ -20,12 +20,15 @@ local assert = assert
 local pairs = pairs
 local setmetatable = setmetatable
 local table_concat = table.concat
+local tostring = tostring
 local source_string = ltn12.source.string
 local table_sink = ltn12.sink.table
 local parse_dsn = util.parse_dsn
 local generate_auth_header = util.generate_auth_header
 local _VERSION = util._VERSION
 local _M = {}
+
+setfenv(1, {})
 
 local mt = {}
 mt.__index = mt

--- a/raven/senders/ngx.lua
+++ b/raven/senders/ngx.lua
@@ -18,21 +18,16 @@
 
 local util = require 'raven.util'
 
+local ngx = ngx
+local debug = debug
+local xpcall = xpcall
+local setmetatable = setmetatable
 local ngx_socket = ngx.socket
 local ngx_get_phase = ngx.get_phase
 local string_format = string.format
 local table_remove = table.remove
 local parse_dsn = util.parse_dsn
 local generate_auth_header = util.generate_auth_header
-local _VERSION = util._VERSION
-local _M = {}
-
-setfenv(1, {})
-
--- provide a more sensible implementation of the error log function
-function util.errlog(...)
-    ngx.log(ngx.ERR, 'raven-lua failure: ', ...)
-end
 
 -- as we don't want to use an external HTTP library, just send the HTTP request
 -- directly using cosocket API
@@ -46,6 +41,16 @@ X-Sentry-Auth: %s
 
 %s
 ]], '\r?\n', '\r\n')
+
+local _VERSION = util._VERSION
+local _M = {}
+
+setfenv(1, {})
+
+-- provide a more sensible implementation of the error log function
+function util.errlog(...)
+    ngx.log(ngx.ERR, 'raven-lua failure: ', ...)
+end
 
 local CALLBACK_DEFAULT_ERRMSG =
     "failed to configure socket (custom callback did not returned a value)"

--- a/raven/senders/ngx.lua
+++ b/raven/senders/ngx.lua
@@ -27,6 +27,8 @@ local generate_auth_header = util.generate_auth_header
 local _VERSION = util._VERSION
 local _M = {}
 
+setfenv(1, {})
+
 -- provide a more sensible implementation of the error log function
 function util.errlog(...)
     ngx.log(ngx.ERR, 'raven-lua failure: ', ...)

--- a/raven/senders/test.lua
+++ b/raven/senders/test.lua
@@ -5,7 +5,9 @@
 -- @copyright 2014-2017 CloudFlare, Inc.
 -- @license BSD 3-clause (see LICENSE file)
 local cjson = require 'cjson'
+local table = table
 
+setfenv(1, {})
 
 local function new()
     return {

--- a/raven/util.lua
+++ b/raven/util.lua
@@ -13,6 +13,11 @@ local string_sub = string.sub
 local string_match = string.match
 local math_random = math.random
 local os_date = os.date
+local tonumber = tonumber
+local assert = assert
+local type = type
+
+setfenv(1, {})
 
 local _M = {}
 


### PR DESCRIPTION
This allows passing a custom `conf` object for ad-hoc config overrides to `send_report` without having to copy paste the entire `call` function if that's all you need.